### PR TITLE
lint対応とスタイルの調整で壊れていたテストを直した

### DIFF
--- a/components/__tests__/prefChart.spec.ts
+++ b/components/__tests__/prefChart.spec.ts
@@ -242,7 +242,7 @@ describe('PrefChart', () => {
       await vm.setSeries()
       const series = vm.chartOptions.series[0]
       expect(series).toBeDefined()
-      expect(series.id).toBe(1)
+      expect(series.id).toBe('1')
       expect(series.name).toBe('北海道')
       expect(series.type).toBe('line')
       expect(series.data).toBeDefined()
@@ -255,7 +255,7 @@ describe('PrefChart', () => {
       const vm = wrapper.vm as PrefChartMock
       store.selectedPrefectures = [2]
       await vm.setSeries()
-      expect(vm.chartOptions.series[0].id).toBe(2)
+      expect(vm.chartOptions.series[0].id).toBe('2')
     })
   })
 })

--- a/components/__tests__/prefSideBar.spec.ts
+++ b/components/__tests__/prefSideBar.spec.ts
@@ -239,9 +239,6 @@ if (buttons[0] && buttons[1]) {
 
       // 基本的なクラスの確認
       expect(sideBar.classes()).toContain('side-bar')
-      expect(sideBar.classes()).toContain('mt-2')
-      expect(content.classes()).toContain('flex')
-      expect(content.classes()).toContain('flex-col')
 
       // コンテンツの存在確認
       expect(content.exists()).toBe(true)
@@ -259,7 +256,6 @@ if (buttons[0] && buttons[1]) {
       // クラスの確認
       expect(sideBar.classes()).toContain('side-bar')
       expect(content.classes()).toContain('side-bar-item-content')
-      expect(content.classes()).toContain('flex')
 
       // 子要素の確認
       const buttons = wrapper.findAll('button')
@@ -278,7 +274,6 @@ if (buttons[0] && buttons[1]) {
       expect(sideBar.classes()).toContain('side-bar')
       expect(content.exists()).toBe(true)
       expect(content.classes()).toContain('side-bar-item-content')
-      expect(content.classes()).toContain('flex')
 
       // ボタンの存在確認とスクロール必要性の確認
       const buttons = wrapper.findAll('button')


### PR DESCRIPTION
## 概要
表題通り

## 対応内容
- linterの指摘対応で、IDが文字列になったところが数字のままだったので修正した。
- スタイル調整でCSSに移した要素がtailwindのままだったので、修正した